### PR TITLE
Fixed index out-of-bounds issue caused when `index<l.startIndex`

### DIFF
--- a/log.go
+++ b/log.go
@@ -579,9 +579,10 @@ func (l *Log) compact(index uint64, term uint64) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if index == 0 {
+	if index == 0 || index < l.startIndex {
 		return nil
 	}
+
 	// nothing to compaction
 	// the index may be greater than the current index if
 	// we just recovery from on snapshot


### PR DESCRIPTION
fix https://github.com/seaweedfs/seaweedfs/issues/4435