### PR TITLE
fix: make syncDir a no-op on Windows

### DIFF
--- a/server.go
+++ b/server.go
@@ -1613,15 +1613,6 @@ func (s *server) writeState(currentTerm uint64, votedFor string) {
 	}
 }
 
-func syncDir(dir string) error {
-	f, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return f.Sync()
-}
-
 //--------------------------------------
 // Debugging
 //--------------------------------------

--- a/syncdir_unix.go
+++ b/syncdir_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package raft
+
+import "os"
+
+// syncDir fsyncs the directory so that a preceding rename is durable.
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/syncdir_windows.go
+++ b/syncdir_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package raft
+
+// syncDir is a no-op on Windows. FlushFileBuffers requires a handle opened
+// with GENERIC_WRITE, but os.Open opens directories read-only, so calling
+// Sync on the resulting handle returns ERROR_ACCESS_DENIED. Windows also
+// has no portable equivalent of fsync(dir_fd): NTFS journals metadata
+// operations (including renames), so directory entries reach disk via the
+// filesystem's own ordering guarantees rather than an explicit dir flush.
+func syncDir(dir string) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- `writeState`'s `syncDir` call panicked on Windows with `ERROR_ACCESS_DENIED` (`Zugriff verweigert`), taking down `weed master` on every term-persisting write. Reported in [seaweedfs/seaweedfs#9292](https://github.com/seaweedfs/seaweedfs/issues/9292).
- Root cause: `os.Open(dir)` returns a read-only handle, but `f.Sync()` on Windows maps to `FlushFileBuffers`, which requires `GENERIC_WRITE`. The first failure happens as soon as the master enters `candidateLoop` after a restart that loaded persisted state.
- Fix: split `syncDir` into build-tagged files. Unix keeps the existing `os.Open` + `f.Sync()` durability path. Windows returns `nil` — there is no portable equivalent of `fsync(dir_fd)` on Windows, and NTFS journals rename metadata so the `state.tmp` -> `state` rename is durable through the filesystem's own ordering.

## Test plan

- [x] `go build ./...` for host, `GOOS=linux`, and `GOOS=windows`
- [x] `go vet ./...`
- [x] `go test ./...` (relevant `TestServer*State` / `TestServer*Vote` subset green)
- [ ] Confirm a Windows reporter on seaweedfs#9292 can restart `weed mini` cleanly with a build off this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved state persistence handling with platform-specific optimizations for Unix and Windows systems to ensure proper data durability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->